### PR TITLE
Add cygwin support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,15 @@
 'use strict';
 var execFile = require('child_process').execFile;
 var findVersions = require('find-versions');
+var cygwin = process.platform === "win32" && (process.env.ORIGINAL_PATH || '').indexOf('/cygdrive/') != -1;
 
 module.exports = function (bin, cb) {
-	execFile(bin, ['--version'], function (err, stdout, stderr) {
+	var args = ['--version'];
+	if(cygwin) {
+		args = ['-c', bin + ' --version'];
+		bin = 'c:\\cygwin\\bin\\bash.exe';
+	}
+	execFile(bin, args, function (err, stdout, stderr) {
 		if (err) {
 			if (err.code === 'ENOENT') {
 				err.message = 'Couldn\'t find the `' + bin + '` binary. Make sure it\'s installed and in your $PATH';


### PR DESCRIPTION
usually, cygwin is installed in c:\\cygwin\\bin\\bash.exe.
This is not a 100% proof patch but should work on 90% of installations.