### PR TITLE
Add support for using multiple commands

### DIFF
--- a/fixture/sub-command.js
+++ b/fixture/sub-command.js
@@ -1,0 +1,4 @@
+#!/usr/bin/env node
+if (process.argv.slice(2)[0] === 'version') {
+	console.log('0.0.0');
+}

--- a/index.js
+++ b/index.js
@@ -1,15 +1,39 @@
 'use strict';
 const execa = require('execa');
 const findVersions = require('find-versions');
+const pLocate = require('p-locate');
+
+const subCommandBinaries = [
+	'openssl',
+	'swiftlint'
+];
+
+const getArgs = (binary, args) => {
+	if (Array.isArray(args)) {
+		return [args];
+	}
+
+	if (subCommandBinaries.includes(binary)) {
+		return [['version']];
+	}
+
+	return [
+		['--version'],
+		['version']
+	];
+};
+
+const getVersion = (binary, args) => execa(binary, args)
+	.then(result => findVersions(result.stdout || result.stderr, {loose: true})[0])
+	.catch(error => {
+		if (error.code === 'ENOENT') {
+			error.message = `Couldn't find the \`${binary}\` binary. Make sure it's installed and in your $PATH`;
+		}
+
+		throw error;
+	});
 
 module.exports = (binary, options = {}) => {
-	return execa(binary, options.args || ['--version'])
-		.then(result => findVersions(result.stdout || result.stderr, {loose: true})[0])
-		.catch(error => {
-			if (error.code === 'ENOENT') {
-				error.message = `Couldn't find the \`${binary}\` binary. Make sure it's installed and in your $PATH`;
-			}
-
-			throw error;
-		});
+	const versions = getArgs(binary, options.args).map(argument => getVersion(binary, argument));
+	return pLocate(versions, version => Boolean(version), {concurrency: 1});
 };

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
 	],
 	"dependencies": {
 		"execa": "^1.0.0",
-		"find-versions": "^3.0.0"
+		"find-versions": "^3.0.0",
+		"p-locate": "^3.0.0"
 	},
 	"devDependencies": {
 		"ava": "^1.0.0-rc.1",

--- a/test.js
+++ b/test.js
@@ -22,3 +22,7 @@ test('openssl', async t => {
 test('php', async t => {
 	t.is(await binVersion('./fixture/php.js'), '7.0.0');
 });
+
+test('sub-command', async t => {
+	t.is(await binVersion('./fixture/sub-command.js'), '0.0.0');
+});


### PR DESCRIPTION
As the title says, this adds support for using multiple commands. By default, if no arguments is specified, we check for `--version` and `version` if it's not a known binary that uses sub-command.

Fixes #12.