### PR TITLE
find-versions@^4.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
 	],
 	"dependencies": {
 		"execa": "^1.0.0",
-		"find-versions": "^3.0.0"
+		"find-versions": "^4.0.0"
 	},
 	"devDependencies": {
 		"ava": "^2.1.0",


### PR DESCRIPTION
looks like the only significant change to find-versions is requiring node >= 8 which this already requires

this will resolve this snyk vulnerability https://snyk.io/test/npm/find-versions/3.2.0